### PR TITLE
add extra labels for mobile-cli and randomize config map name

### DIFF
--- a/cmd/server/upsClient.go
+++ b/cmd/server/upsClient.go
@@ -11,6 +11,7 @@ import (
 
 type upsClient struct {
 	config *pushApplication
+	serviceInstanceId string
 	baseUrl string
 }
 


### PR DESCRIPTION
Add the extra labels needes by the mobile-cli and randomize the name of the config map.

Verification steps:
1. Create an binding of type android
1. Make sure that the variant has been created in UPS
1. Check Resources -> Config Maps. A ConfigMap for the Variant should have been created. The name of the config map should end with a random string
1. Delete the binding
1. The variant should be gone and the config map should also be deleted