### PR TITLE
iOS - implemented deletion of configmap and variant

### DIFF
--- a/cmd/server/upsClient.go
+++ b/cmd/server/upsClient.go
@@ -19,6 +19,59 @@ type upsClient struct {
 
 const BaseUrl = "http://localhost:8080/rest/applications"
 
+func (client *upsClient) deleteIOSVariant(variantId string) bool {
+	variant := client.hasIOSVariant(variantId)
+	if variant != nil {
+		log.Printf("Deleting variant with id `%s`", variant.VariantID)
+
+		url := fmt.Sprintf("%s/%s/adm/%s", BaseUrl, client.config.ApplicationId, variant.VariantID)
+		log.Printf("UPS request", url)
+
+		req, err := http.NewRequest(http.MethodDelete, url, nil)
+
+		httpClient := http.Client{}
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			log.Fatal(err.Error())
+			return false
+		}
+
+		log.Printf("Variant `%s` has been deleted", variant.VariantID)
+		return resp.StatusCode == 204
+	}
+
+	log.Printf("No variant found to delete (Variant Id: `%s`)", variantId)
+	return false
+}
+
+// Find an iOS Variant by it's variant id
+func (client *upsClient) hasIOSVariant(variantId string) *iOSVariant {
+	url := fmt.Sprintf("%s/%s/ios", BaseUrl, client.config.ApplicationId)
+	log.Printf("UPS request", url)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Fatal(err)
+
+		// Return true here to prevent creating a new variant when the
+		// request fails
+		return &iOSVariant{}
+	}
+
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+	variants := make([]iOSVariant, 0)
+	json.Unmarshal(body, &variants)
+
+	for _, variant := range variants {
+		if variant.VariantID == variantId {
+			return &variant
+		}
+	}
+
+	return nil
+}
+
 // Delete the variant with the given google key
 func (client *upsClient) deleteVariant(key string) bool {
 	variant := client.hasAndroidVariant(key)


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-2546

What: This change modifies the creation of the configmap and binding secret to include a unique referenceId which can be used for identifying the variant when we need to delete it.

Needs to be verified with UPS apb from this pr: https://github.com/aerogearcatalog/unifiedpush-apb/pull/39

