### PR TITLE
Unifiy variant deletion

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,7 +37,7 @@ const BindingProjectNumber = "projectNumber"
 
 const UpsSecretName = "unified-push-server"
 const UpsURI = "uri"
-const GoogleKey = "googleKey"
+const AppType = "type"
 const IOSCert = "cert"
 const IOSPassPhrase = "passphrase"
 const VariantReferenceId = "variantReferenceId" // this is a specific id for deleting resources such as secrets and configmaps - this is NOT the UPS variant id
@@ -75,8 +75,6 @@ func deleteSecret(name string) {
 func createAndroidVariantConfigMap(variant *androidVariant, clientId string, variantReferenceId string) {
 	//initialise the UPS data which will be used for the configmap value
 	var variantUrl = pushClient.baseUrl + "/#/app/" + pushClient.config.ApplicationId + "/variants/" + variant.VariantID
-
-	log.Print("ups variant url : ", variantUrl)
 
 	// The name of the config map needs to have a random element because there could be
 	// more than one config map per client
@@ -228,7 +226,7 @@ func handleIOSVariant(secret *BindingSecret) {
 	}
 }
 
-func handleDeleteIOSVariant(secret *BindingSecret) {
+func handleDeleteVariant(secret *BindingSecret) {
 	if _, ok := secret.Data[VariantReferenceId]; !ok {
 		log.Println("Secret does not contain a variant reference id, can't delete the variant")
 		return
@@ -242,7 +240,8 @@ func handleDeleteIOSVariant(secret *BindingSecret) {
 	}
 
 	configMapDeleted := false
-	variantId := ""  // UPS variant id of the variant to be deleted
+	var variantId string  // UPS variant id of the variant to be deleted
+    var	appType string
 
 	//Filter config maps to identify the one associated with the given variant reference id
 	for _, config := range configs.Items {
@@ -250,6 +249,7 @@ func handleDeleteIOSVariant(secret *BindingSecret) {
 			name := config.Name
 			log.Printf("Config map with name `%s` has a matching variant reference id", name)
 			variantId = string(config.Data["variantID"])
+			appType = string(config.Data[AppType])
 			// Delete the config map
 			err := k8client.CoreV1().ConfigMaps(os.Getenv(NamespaceKey)).Delete(name, nil)
 			if err != nil {
@@ -268,53 +268,7 @@ func handleDeleteIOSVariant(secret *BindingSecret) {
 
 	// Delete the UPS variant only if the associated config map has been deleted
 	if configMapDeleted == true {
-		pushClient.deleteIOSVariant(variantId)
-	}
-}
-
-func handleDeleteAndroidVariant(secret *BindingSecret) {
-	if _, ok := secret.Data[GoogleKey]; !ok {
-		log.Println("Secret does not contain a google key, can't delete android variant")
-		return
-	}
-
-	googleKey := string(secret.Data[GoogleKey])
-	log.Printf("Deleting config map associated with google key `%s`", googleKey)
-
-	// Get all config maps
-	configs, err := k8client.CoreV1().ConfigMaps(os.Getenv(NamespaceKey)).List(metav1.ListOptions{})
-	if err != nil {
-		panic(err.Error())
-	}
-
-	configMapDeleted := false
-
-	// Filter config maps to identify the one associated with the given google key
-	for _, config := range configs.Items {
-		if config.Labels["resourceType"] == "binding" && config.Data[GoogleKey] == googleKey {
-			name := config.Name
-			log.Printf("Config map with name `%s` has a matching google key", name)
-
-			// Delete the config map
-			err := k8client.CoreV1().ConfigMaps(os.Getenv(NamespaceKey)).Delete(name, nil)
-			if err != nil {
-				log.Fatal("Error deleting config map with name `%s`", name, err)
-				break
-			}
-
-			log.Printf("Config map `%s` has been deleted", name)
-			configMapDeleted = true
-			break
-		}
-	}
-
-	if pushClient == nil {
-		pushClient = pushClientOrDie()
-	}
-
-	// Delete the UPS variant only if the associated config map has been deleted
-	if configMapDeleted == true {
-		pushClient.deleteVariant(googleKey)
+		pushClient.deleteVariant(appType, variantId)
 	}
 }
 
@@ -342,16 +296,10 @@ func handleDeleteSecret(obj runtime.Object) {
 	raw, _ := json.Marshal(obj)
 	var secret = BindingSecret{}
 	json.Unmarshal(raw, &secret)
-	appType := string(secret.Data[BindingAppType])
 
 	for _, ref := range secret.ObjectMeta.OwnerReferences {
-		if ref.Kind == "ServiceBinding" && appType == "Android" {
-			log.Print("A mobile binding secret of type `Android` will be deleted")
-			handleDeleteAndroidVariant(&secret)
-			break
-		} else if ref.Kind == "ServiceBinding" && appType == "IOS"{
-			log.Print("A mobile binding secret of type `iOS` will be deleted")
-			handleDeleteIOSVariant(&secret)
+		if ref.Kind == "ServiceBinding" {
+			handleDeleteVariant(&secret)
 			break
 		}
 	}

--- a/cmd/server/upsClient.go
+++ b/cmd/server/upsClient.go
@@ -19,10 +19,12 @@ type upsClient struct {
 
 const BaseUrl = "http://localhost:8080/rest/applications"
 
-func (client *upsClient) deleteIOSVariant(variantId string) bool {
-	variant := client.hasIOSVariant(variantId)
+func (client *upsClient) deleteVariant(platform string , variantId string) bool {
+	variant := client.hasVariant(platform, variantId)
+
 	if variant != nil {
-		log.Printf("Deleting variant with id `%s`", variant.VariantID)
+		log.Printf("Deleting %s variant with id `%s`", platform,  variant.VariantID)
+		log.Printf("Deleting %s variant with id `%s`", platform,  variant.VariantID)
 
 		url := fmt.Sprintf("%s/%s/adm/%s", BaseUrl, client.config.ApplicationId, variant.VariantID)
 		log.Printf("UPS request", url)
@@ -44,9 +46,9 @@ func (client *upsClient) deleteIOSVariant(variantId string) bool {
 	return false
 }
 
-// Find an iOS Variant by it's variant id
-func (client *upsClient) hasIOSVariant(variantId string) *iOSVariant {
-	url := fmt.Sprintf("%s/%s/ios", BaseUrl, client.config.ApplicationId)
+// Find a Variant by it's variant id
+func (client *upsClient) hasVariant(platform string, variantId string) *variant {
+	url := fmt.Sprintf("%s/%s/%s", BaseUrl, client.config.ApplicationId, platform)
 	log.Printf("UPS request", url)
 
 	resp, err := http.Get(url)
@@ -55,12 +57,12 @@ func (client *upsClient) hasIOSVariant(variantId string) *iOSVariant {
 
 		// Return true here to prevent creating a new variant when the
 		// request fails
-		return &iOSVariant{}
+		return &variant{}
 	}
 
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
-	variants := make([]iOSVariant, 0)
+	variants := make([]variant, 0)
 	json.Unmarshal(body, &variants)
 
 	for _, variant := range variants {
@@ -72,31 +74,6 @@ func (client *upsClient) hasIOSVariant(variantId string) *iOSVariant {
 	return nil
 }
 
-// Delete the variant with the given google key
-func (client *upsClient) deleteVariant(key string) bool {
-	variant := client.hasAndroidVariant(key)
-	if variant != nil {
-		log.Printf("Deleting variant with id `%s`", variant.VariantID)
-
-		url := fmt.Sprintf("%s/%s/adm/%s", BaseUrl, client.config.ApplicationId, variant.VariantID)
-		log.Printf("UPS request", url)
-
-		req, err := http.NewRequest(http.MethodDelete, url, nil)
-
-		httpClient := http.Client{}
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			log.Fatal(err.Error())
-			return false
-		}
-
-		log.Printf("Variant `%s` has been deleted", variant.VariantID)
-		return resp.StatusCode == 204
-	}
-
-	log.Printf("No variant found to delete (google key: `%s`)", key)
-	return false
-}
 
 // Find an Android Variant by it's Google Key
 func (client *upsClient) hasAndroidVariant(key string) *androidVariant {


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-2550

Changes:
Unified the deletion of the variants (ios & android) 

- updates were made to modify the binding secret for the apb in PR https://github.com/aerogearcatalog/unifiedpush-apb/pull/41 (needed to verify this)

- updated the creation of the android configmap to reflect this

- unified the deletion of the two variants regardless of the platform type
