### PR TITLE
Config secrets

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,7 +17,8 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 	"math/rand"
 	"time"
-
+	"fmt"
+	"strings"
 )
 
 var k8client *kubernetes.Clientset
@@ -37,10 +38,8 @@ const BindingProjectNumber = "projectNumber"
 
 const UpsSecretName = "unified-push-server"
 const UpsURI = "uri"
-const AppType = "type"
 const IOSCert = "cert"
 const IOSPassPhrase = "passphrase"
-const VariantReferenceId = "variantReferenceId" // this is a specific id for deleting resources such as secrets and configmaps - this is NOT the UPS variant id
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 
@@ -65,97 +64,11 @@ func getRandomIdentifier(length int) string {
 // Deletes the binding secret after the sync operation has completed
 func deleteSecret(name string) {
 	err := k8client.CoreV1().Secrets(os.Getenv(NamespaceKey)).Delete(name, nil)
+
 	if err != nil {
-		log.Fatal("Error creating config map", err)
+		log.Print("Error deleting secret", err)
 	} else {
 		log.Printf("Secret `%s` has been deleted", name)
-	}
-}
-
-func createAndroidVariantConfigMap(variant *androidVariant, clientId string, variantReferenceId string) {
-	//initialise the UPS data which will be used for the configmap value
-	var variantUrl = pushClient.baseUrl + "/#/app/" + pushClient.config.ApplicationId + "/variants/" + variant.VariantID
-
-	// The name of the config map needs to have a random element because there could be
-	// more than one config map per client
-	variantName := variant.Name + "-config-map-" + getRandomIdentifier(5)
-
-	payload := v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: variantName,
-			Labels: map[string]string{
-				"mobile":       "enabled",
-				"serviceName":  "ups",
-				"resourceType": "binding",
-
-				// Used by the mobile-cli to discover config objects
-				"serviceInstanceId": pushClient.serviceInstanceId,
-				"mobileClientID": clientId,
-			},
-		},
-		Data: map[string]string{
-			"name":          variant.Name,
-			"description":   variant.Description,
-			"variantID":     variant.VariantID,
-			"secret":        variant.Secret,
-			"googleKey":     variant.GoogleKey,
-			"projectNumber": variant.ProjectNumber,
-			"type":          "android",
-			"variantURL":    variantUrl,
-			"variantReferenceId": variantReferenceId,
-		},
-	}
-	_, err := k8client.CoreV1().ConfigMaps(os.Getenv(NamespaceKey)).Create(&payload)
-	if err != nil {
-		log.Fatal("Error creating config map", err)
-	} else {
-		log.Printf("Config map `%s` for variant created", variantName)
-	}
-}
-
-func createIOSVariantConfigMap(variant *iOSVariant, clientId string, variantReferenceId string) {
-	//initialise the UPS data which will be used for the configmap value
-	var variantUrl = pushClient.baseUrl + "/#/app/" + pushClient.config.ApplicationId + "/variants/" + variant.VariantID
-
-	log.Print("ups variant url : ", variantUrl)
-
-	// The name of the config map needs to have a random element because there could be
-	// more than one config map per client
-	variantName := variant.Name + "-config-map-" + getRandomIdentifier(5)
-
-	production := "true"
-	if !variant.Production {
-		production = "false"
-	}
-	payload := v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: variantName,
-			Labels: map[string]string{
-				"mobile":       "enabled",
-				"serviceName":  "ups",
-				"resourceType": "binding",
-
-				// Used by the mobile-cli to discover config objects
-				"serviceInstanceId": pushClient.serviceInstanceId,
-				"mobileClientID": clientId,
-			},
-		},
-		Data: map[string]string{
-			"name":          variant.Name,
-			"description":   variant.Description,
-			"variantID":     variant.VariantID,
-			"secret":        variant.Secret,
-		    "production":	production,
-			"type":          "ios",
-			"variantURL":    variantUrl,
-			"variantReferenceId": variantReferenceId,
-		},
-	}
-	_, err := k8client.CoreV1().ConfigMaps(os.Getenv(NamespaceKey)).Create(&payload)
-	if err != nil {
-		log.Fatal("Error creating config map", err)
-	} else {
-		log.Printf("Config map `%s` for variant created", variantName)
 	}
 }
 
@@ -169,7 +82,6 @@ func handleAndroidVariant(secret *BindingSecret) {
 	clientId := string(secret.Data[BindingClientId])
 	googleKey := string(secret.Data[BindingGoogleKey])
 	projectNumber := string(secret.Data[BindingProjectNumber])
-	variantReferenceId := string(secret.Data[VariantReferenceId])
 
 	if pushClient.hasAndroidVariant(googleKey) == nil {
 		payload := &androidVariant{
@@ -185,9 +97,10 @@ func handleAndroidVariant(secret *BindingSecret) {
 		log.Print("Creating a new android variant", payload)
 		success, variant := pushClient.createAndroidVariant(payload)
 		if success {
-			createAndroidVariantConfigMap(variant, clientId, variantReferenceId)
+			config, _ := variant.getJson()
+			updateConfiguration("android", clientId, variant.VariantID, config)
 		} else {
-			log.Fatal("No variant has been created in UPS, skipping config map")
+			log.Println("No variant has been created in UPS, skipping config map")
 		}
 	} else {
 		log.Printf("A variant for google key '%s' already exists", googleKey)
@@ -204,7 +117,6 @@ func handleIOSVariant(secret *BindingSecret) {
 	clientId := string(secret.Data[BindingClientId])
 	cert := string(secret.Data[IOSCert])
 	passPhrase := string(secret.Data[IOSPassPhrase])
-	variantReferenceId := string(secret.Data[VariantReferenceId])
 
 	certByteArray := []byte (cert)
 	payload := &iOSVariant{
@@ -220,56 +132,165 @@ func handleIOSVariant(secret *BindingSecret) {
 
 	success, variant := pushClient.createIOSVariant(payload)
 	if success {
-		createIOSVariantConfigMap(variant, clientId, variantReferenceId)
+		config, _ := variant.getJson()
+		updateConfiguration("ios", clientId, variant.VariantID, config)
 	} else {
 		log.Print("No variant has been created in UPS, skipping config map")
 	}
 }
 
 func handleDeleteVariant(secret *BindingSecret) {
-	if _, ok := secret.Data[VariantReferenceId]; !ok {
-		log.Println("Secret does not contain a variant reference id, can't delete the variant")
-		return
-	}
-	variantReferenceId := string(secret.Data[VariantReferenceId])
+	appType := strings.ToLower(string(secret.Data["appType"]))
+	success, variantId := removeConfigFromClientSecret(secret)
 
-	// Get all config maps
-	configs, err := k8client.CoreV1().ConfigMaps(os.Getenv(NamespaceKey)).List(metav1.ListOptions{})
+	if success {
+		pushClient.deleteVariant(appType, variantId)
+	}
+}
+
+func findMobileClientConfig(clientId string) *v1.Secret {
+	filter := metav1.ListOptions{LabelSelector: fmt.Sprintf("clientId=%s,serviceName=ups", clientId)}
+	secrets, err := k8client.CoreV1().Secrets(os.Getenv(NamespaceKey)).List(filter)
+
+	if err !=  nil {
+		panic(err.Error())
+	}
+
+	// No secret exists yet, that's ok, we have to create one
+	if len(secrets.Items) == 0 {
+		return nil
+	}
+
+	// Multiple secrets for the same clientId found, that's anerror
+	if len(secrets.Items) > 1 {
+		panic(fmt.Sprintf("Multiple secrets found for clientId %s", clientId))
+	}
+
+	return &secrets.Items[0]
+}
+
+func createClientConfigSecret(clientId string) *v1.Secret {
+	configSecretName := fmt.Sprintf("variant-secret-%s-%s", clientId, getRandomIdentifier(5))
+
+	payload := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: configSecretName,
+			Labels: map[string]string{
+				"mobile":       "enabled",
+				"serviceName":  "ups",
+
+				// Used by the mobile-cli to discover config objects
+				"serviceInstanceId": pushClient.serviceInstanceId,
+				"clientId": clientId,
+			},
+		},
+		Data: map[string][]byte{
+			"config": []byte(fmt.Sprintf("{\"pushServerUrl\":\"%s\"}", pushClient.baseUrl)),
+		},
+	}
+
+	secret, err := k8client.CoreV1().Secrets(os.Getenv(NamespaceKey)).Create(&payload)
+	if err != nil {
+		log.Fatal("Error creating config map", err)
+	} else {
+		log.Printf("Config secret `%s` for variant created", configSecretName)
+	}
+
+	return secret
+}
+
+func removeConfigFromClientSecret(secret *BindingSecret) (bool, string) {
+	clientId := string(secret.Data["clientId"])
+	configSecret := findMobileClientConfig(clientId)
+
+	if configSecret == nil {
+		log.Printf("Cannot delete config secret for client `%s` because it does not exist", clientId)
+		return false, ""
+	}
+
+	appType := strings.ToLower(string(secret.Data["appType"]))
+	log.Printf("Deleting %s configuration from `%s`", appType, clientId)
+
+	// Get the current config
+	// Retrieve the current config as an object
+	var currentConfig map[string]json.RawMessage
+	json.Unmarshal(configSecret.Data["config"], &currentConfig)
+
+	// Get the variant ID before removing the config
+	// We need that to delete the variant in UPS
+	variantId := getVariantIdFromConfig(string(currentConfig[appType]))
+
+	// If there is only one platform in the configuration we can remove the whole
+	// secret (2 because there is another key for the server url)
+	if (len(currentConfig) == 2) {
+		deleteSecret(configSecret.Name)
+		return true, variantId
+	} else {
+		log.Println("More than one variant available, updating configuration object")
+
+		// Delete the config of the given app type and it's URL annotation
+		delete(currentConfig, appType)
+		delete(configSecret.Annotations, appType)
+
+		// Create a string of the new config object
+		currentConfigString, err := json.Marshal(currentConfig)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		configSecret.Data["config"] = currentConfigString
+		_, err = k8client.CoreV1().Secrets(os.Getenv(NamespaceKey)).Update(configSecret)
+		if err != nil {
+			log.Println(err.Error())
+		}
+
+		return true, variantId
+	}
+}
+
+func getVariantIdFromConfig(config string) string {
+	configMap := make(map[string]string)
+	json.Unmarshal([]byte(config), &configMap)
+	return configMap["variantId"]
+}
+
+func updateConfiguration(appType string, clientId string, variantId string, config []byte) {
+	configSecret := findMobileClientConfig(clientId)
+	if configSecret == nil {
+		// No config secret exists for this client yet. Create one.
+		configSecret = createClientConfigSecret(clientId)
+	}
+
+	// Retrieve the current config as an object
+	var currentConfig map[string]json.RawMessage
+	json.Unmarshal(configSecret.Data["config"], &currentConfig)
+
+	// Overwrite the old platform config
+	currentConfig[appType] = []byte(config)
+
+	// Create a string of the complete config object
+	currentConfigString, err := json.Marshal(currentConfig)
+
 	if err != nil {
 		panic(err.Error())
 	}
 
-	configMapDeleted := false
-	var variantId string  // UPS variant id of the variant to be deleted
-    var	appType string
+	// Set the new config
+	configSecret.Data["uri"] = []byte(pushClient.baseUrl)
+	configSecret.Data["config"] = currentConfigString
+	configSecret.Data["name"] = []byte("ups")
+	configSecret.Data["type"] = []byte("AeroGear Unifiedpush Server")
 
-	//Filter config maps to identify the one associated with the given variant reference id
-	for _, config := range configs.Items {
-		if config.Labels["resourceType"] == "binding" && config.Data[VariantReferenceId] == variantReferenceId {
-			name := config.Name
-			log.Printf("Config map with name `%s` has a matching variant reference id", name)
-			variantId = string(config.Data["variantID"])
-			appType = string(config.Data[AppType])
-			// Delete the config map
-			err := k8client.CoreV1().ConfigMaps(os.Getenv(NamespaceKey)).Delete(name, nil)
-			if err != nil {
-				log.Fatal("Error deleting config map with name `%s`", name, err)
-				break
-			}
-			configMapDeleted = true
-			log.Printf("Config map `%s` has been deleted", name)
-			break
-		}
-	}
+	variantUrl := pushClient.baseUrl + "/#/app/" + pushClient.config.ApplicationId + "/variants/" + variantId
+	urlAnnotation := fmt.Sprintf("variant/%s", appType)
 
-	if pushClient == nil {
-		pushClient = pushClientOrDie()
+	if (configSecret.Annotations == nil) {
+		configSecret.Annotations = make(map[string]string)
 	}
+	configSecret.Annotations[urlAnnotation] = variantUrl
 
-	// Delete the UPS variant only if the associated config map has been deleted
-	if configMapDeleted == true {
-		pushClient.deleteVariant(appType, variantId)
-	}
+	k8client.CoreV1().Secrets(os.Getenv(NamespaceKey)).Update(configSecret)
+	log.Printf("%s configuration of %s has been updated", appType, clientId)
 }
 
 func handleAddSecret(obj runtime.Object) {

--- a/cmd/server/types.go
+++ b/cmd/server/types.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
 type variant struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
@@ -22,4 +27,31 @@ type iOSVariant struct {
 
 type pushApplication struct {
 	ApplicationId string `json:"applicationId"`
+}
+
+func (this *androidVariant) getJson() ([]byte, error) {
+	config := map[string]string{
+		"senderId": this.ProjectNumber,
+		"variantId": this.VariantID,
+		"variantSecret": this.Secret,
+	}
+
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(config)
+	return buffer.Bytes(), err
+}
+
+func (this *iOSVariant) getJson() ([]byte, error) {
+	config := map[string]string{
+		"variantId": this.VariantID,
+		"variantSecret": this.Secret,
+	}
+
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(config)
+	return buffer.Bytes(), err
 }

--- a/cmd/server/upsClient.go
+++ b/cmd/server/upsClient.go
@@ -24,7 +24,6 @@ func (client *upsClient) deleteVariant(platform string , variantId string) bool 
 
 	if variant != nil {
 		log.Printf("Deleting %s variant with id `%s`", platform,  variant.VariantID)
-		log.Printf("Deleting %s variant with id `%s`", platform,  variant.VariantID)
 
 		url := fmt.Sprintf("%s/%s/adm/%s", BaseUrl, client.config.ApplicationId, variant.VariantID)
 		log.Printf("UPS request", url)
@@ -112,6 +111,8 @@ func (client *upsClient) createAndroidVariant(variant *androidVariant) (bool, *a
 		panic(err.Error())
 	}
 
+	log.Println("UPS Payload", string(payload))
+
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payload))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
@@ -122,7 +123,7 @@ func (client *upsClient) createAndroidVariant(variant *androidVariant) (bool, *a
 		panic(err.Error())
 	}
 
-	log.Printf("UPS responded with status code ", resp.Status)
+	log.Printf("UPS responded with status code ", resp.StatusCode)
 
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Change the way USP variants are stored on the Openshift side from a config map per variant to a secret per mobile client. Multiple variants can be stored in one secret. The secrets are generated in a way that allows the cli to pick up the configuration, e.g. a cordova app with two variants (android and ios):

```
⇒  mobile get clientconfig myapp-cordova --namespace=myproject -o json
{
	"version": 1,
	"clusterName": "https://192.168.37.1:8443",
	"namespace": "myproject",
	"clientId": "myapp-cordova",
	"services": [
		{
			"id": "ups-secret-myapp-cordova-f3e99",
			"name": "ups",
			"type": "AeroGear Unifiedpush Server",
			"url": "https://ups-myproject.192.168.37.1.nip.io",
			"config": {
				"android": {
					"senderId": "1234",
					"variantId": "58aaa1c6-990e-408e-af8c-90cd18c7795d",
					"variantSecret": "18e61b63-dfed-4e26-a0bf-82ca3a7a0883"
				},
				"ios": {
					"variantId": "de0c3640-6c06-494c-b268-08f6fbd3bdf3",
					"variantSecret": "c37eec71-25af-46f6-811f-a9a87e09e142"
				},
				"pushServerUrl": "https://ups-myproject.192.168.37.1.nip.io"
			}
		}
	]
}
```

Verification steps:

1. Must be used together with https://github.com/aerogearcatalog/unifiedpush-apb/pull/45
1. Checkout this branch, build the image and deploy it to you ups apb
1. Deploy a cordova app (or any other, but cordova is a good use case)
1. Use 'create binding' to create an android and an ios variant for this app.
1. Use the mobile-cli to retrieve the config: `mobile get clientconfig <app id> --namespace=<namespace> -o json`
1. It should return the configuration for both variants. The format should be similar to https://github.com/aerogear/aerogear-cordova-push/blob/master/example/push-config.json
1. Go to Resources -> Secrets and open the one starting with `ups-secret-<appid>-<random>`
1. Open the yaml of the secret. It should have annotations with the URLs for the variants.
1. Open the URLs in a browser. It should expand the selected variant.
1. Delete one variant and retrieve the config again. It should have been removed.
1. Delete the other variant. No configuration should be left and the secret should be deleted.