### PR TITLE
fix: parse the isProduction flag from iOS variant secret

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -389,8 +389,6 @@ func pushClientOrDie() *upsClient {
 func main() {
 	rand.Seed(time.Now().Unix())
 
-	log.Print("Hello this is Dara's custom service")
-
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		panic(err.Error())


### PR DESCRIPTION
Related issue: https://issues.jboss.org/browse/AEROGEAR-2562

## Verification Steps

Use [this branch of the unifiedpush-apb](https://github.com/aerogearcatalog/unifiedpush-apb/pull/49) to provision the service. Note that the isProduction checkbox should result in the appropriate variant being created UPS.