### PR TITLE
fix variant delete

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -156,7 +156,10 @@ func handleDeleteVariant(secret *BindingSecret) {
 	success, variantId := removeConfigFromClientSecret(secret)
 
 	if success {
-		pushClient.deleteVariant(appType, variantId)
+		success := pushClient.deleteVariant(appType, variantId)
+		if !success {
+			log.Printf("UPS reported an error when deleting variant %s", variantId)
+		}
 	}
 }
 

--- a/cmd/server/upsClient.go
+++ b/cmd/server/upsClient.go
@@ -25,7 +25,9 @@ func (client *upsClient) deleteVariant(platform string , variantId string) bool 
 	if variant != nil {
 		log.Printf("Deleting %s variant with id `%s`", platform,  variant.VariantID)
 
-		url := fmt.Sprintf("%s/%s/adm/%s", BaseUrl, client.config.ApplicationId, variant.VariantID)
+		url := fmt.Sprintf("%s/%s/%s/%s", BaseUrl, client.config.ApplicationId,
+			platform, variant.VariantID)
+
 		log.Printf("UPS request", url)
 
 		req, err := http.NewRequest(http.MethodDelete, url, nil)
@@ -37,7 +39,7 @@ func (client *upsClient) deleteVariant(platform string , variantId string) bool 
 			return false
 		}
 
-		log.Printf("Variant `%s` has been deleted", variant.VariantID)
+		log.Printf("Variant `%s` has been deleted (status code %d)", variant.VariantID, resp.StatusCode)
 		return resp.StatusCode == 204
 	}
 


### PR DESCRIPTION
We used the wrong URL when deleting variants (it contained `adm` which refers to Amazon Device Messaging). ADM support was removed from UPS with this commit: https://github.com/aerogear/aerogear-unifiedpush-server/commit/3a05c579ff8fff957210c4997e3ffaee38d9876a

It suppose that it accidentally worked until then because UPS was happy to get a valid variant ID and didn't check the type. This is a UPS Bug and should be resolved. 