### PR TITLE
Poll UPS to check for deleted variants

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -532,7 +532,7 @@ func getUPSSecrets() ([]v1.Secret, error) {
 }
 
 func handleDeleteServiceBinding(servicebindingId string) error {
-	serviceBindingName, err := getServiceBindingNameByID(config["servicebindingId"])
+	serviceBindingName, err := getServiceBindingNameByID(servicebindingId)
 	if err != nil {
 		return err
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -52,7 +52,7 @@ const IOSPassPhrase = "passphrase"
 const IOSIsProduction = "isProduction"
 
 // time in seconds
-const UPSPollingInterval = 5
+const UPSPollingInterval = 10
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -178,6 +178,7 @@ func compareUPSVariantsWithClientConfigs() {
 		for _, variant := range UPSVariants {
 			if variant.VariantID == clientConfig.VariantId {
 				found = true
+				break
 			}
 		}
 
@@ -252,7 +253,7 @@ func getServiceBindingNameByID(bindingId string) (string, error) {
 	// does not support jsonpath or at least I could not find any examples.
 	bindings, err := scclient.ServicecatalogV1beta1().ServiceBindings(os.Getenv(NamespaceKey)).List(metav1.ListOptions{})
 	if err != nil {
-		return "", errors.New("Error listing service bindings")
+		return "", err
 	}
 
 	for _, binding := range bindings.Items {

--- a/cmd/server/types.go
+++ b/cmd/server/types.go
@@ -20,9 +20,14 @@ type androidVariant struct {
 
 type iOSVariant struct {
 	Certificate []byte `json:"certificate"`
-	Passphrase string `json:"passphrase"`
-	Production bool `json:"production"`
+	Passphrase  string `json:"passphrase"`
+	Production  bool   `json:"production"`
 	variant
+}
+
+type variantList struct {
+	Android []androidVariant
+	IOS     []iOSVariant
 }
 
 type pushApplication struct {
@@ -37,8 +42,8 @@ type VariantAnnotation struct {
 
 func (this *androidVariant) getJson() ([]byte, error) {
 	config := map[string]string{
-		"senderId": this.ProjectNumber,
-		"variantId": this.VariantID,
+		"senderId":      this.ProjectNumber,
+		"variantId":     this.VariantID,
 		"variantSecret": this.Secret,
 	}
 
@@ -51,7 +56,7 @@ func (this *androidVariant) getJson() ([]byte, error) {
 
 func (this *iOSVariant) getJson() ([]byte, error) {
 	config := map[string]string{
-		"variantId": this.VariantID,
+		"variantId":     this.VariantID,
 		"variantSecret": this.Secret,
 	}
 
@@ -60,4 +65,10 @@ func (this *iOSVariant) getJson() ([]byte, error) {
 	encoder.SetEscapeHTML(false)
 	err := encoder.Encode(config)
 	return buffer.Bytes(), err
+}
+
+type UPSClientConfig struct {
+	Android       *map[string]string `json:"android,omitempty"`
+	IOS           *map[string]string `json:"ios,omitempty"`
+	PushServerURL string             `json:"pushServerUrl,omitempty"`
 }

--- a/cmd/server/types.go
+++ b/cmd/server/types.go
@@ -25,11 +25,6 @@ type iOSVariant struct {
 	variant
 }
 
-type variantList struct {
-	Android []androidVariant
-	IOS     []iOSVariant
-}
-
 type pushApplication struct {
 	ApplicationId string `json:"applicationId"`
 }
@@ -37,7 +32,7 @@ type pushApplication struct {
 type VariantAnnotation struct {
 	Label string `json:"label"`
 	Value string `json:"value"`
-	Type string `json:"type"`
+	Type  string `json:"type"`
 }
 
 func (this *androidVariant) getJson() ([]byte, error) {

--- a/cmd/server/types.go
+++ b/cmd/server/types.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+
+	"github.com/pkg/errors"
 )
 
 type variant struct {
@@ -66,4 +68,26 @@ type UPSClientConfig struct {
 	Android       *map[string]string `json:"android,omitempty"`
 	IOS           *map[string]string `json:"ios,omitempty"`
 	PushServerURL string             `json:"pushServerUrl,omitempty"`
+}
+
+type VariantServiceBindingMapping struct {
+	VariantId        string
+	ServiceBindingId string
+}
+
+func GetClientConfigRepresentation(variantId, serviceBindingId string) (VariantServiceBindingMapping, error) {
+	config := VariantServiceBindingMapping{
+		VariantId:        variantId,
+		ServiceBindingId: serviceBindingId,
+	}
+	return config, config.Validate()
+}
+
+func (configRepresentation *VariantServiceBindingMapping) Validate() error {
+	if configRepresentation.VariantId == "" {
+		return errors.New("missing variantId")
+	} else if configRepresentation.ServiceBindingId == "" {
+		return errors.New("missing serviceBindingId")
+	}
+	return nil
 }


### PR DESCRIPTION
Related Ticket: https://issues.jboss.org/browse/AEROGEAR-2647

## Description

This PR implements a mechanism where every 10 seconds, the service polls UPS to build a list of all variants. It then compares those variants against the UPS secrets created in K8s to see if there are any client configs that reference a variant that no longer exists in UPS. If we find a client UPS config that references a variant that does not exist, we assume the variant has been deleted and we trigger an unbind by deleting the servicebinding relating to that particular variant.

One issue I have found is that when we notice a variant has been deleted in UPS, we delete the servicebinding, this results in the bind secret being deleted which results in the `handleDelete` function being triggered which makes a call to UPS to delete the variant but the variant has already been deleted. Not sure what we should do here...

### Some additional notes

* I've also done some minor refactoring in the pushClient.go
* My editor has some automatic `gofmt` thing so you may see some stylistic changes in places.
* `main.go` is getting really bloated and readability is suffering big time. This should definitely be resolved in another PR but for now, I've tried to make some minor improvements by bringing the `main()`, `startWatchLoop()` and `startPollingUPS()` functions to the top.

### To Do

- [x] some of the function and variable names are probably not the best and could be renamed
- [x] I'm trying to figure out how to make the code simpler to understand
- [x] need to refactor the `pushClientOrDie` function to not die if an error occurs. 
- [x]  We can then implement the appropriate nil checks and error checks in places we use the pushClient.

@pb82 would love to get your thoughts on this.

## How to Verify

### Setup

To make it easier to verify, I've pushed an image based off this PR to `docker.io/darahayes/ups-config-operator:master`. This means you don't need to clone the code and build locally. You can trust that the code builds based off the build in CircleCI.

* Ensure you have the latest unifiedpush-apb image with `docker pull aerogear/catalog/unifiedpush-apb`
* Provision UPS from the service catalog as normal. Do not create any bindings at this time
* In OpenShift, go into deployments/ups and replace `docker.io/aerogear/ups-config-operator:master` with `docker.io/darahayes/ups-config-operator:master`. Hit save. This should kick off a new deployment.
* Create some bindings on the UPS service for iOS/Android clients.
* You should see the associated variants in UPS and also under resoruces/secrets in OpenShift you should find a secret with a name like `ups-secret-<my-client-id>-abcjd` inside the `config` property of this secret(s) you will find the config that should be consumed by the client. There will be fields for `android` and `ios` depending on the bindings you created.

### Actions

* In the UPS console, delete a variant.
* After a few seconds, verify that the servicebinding associated with this variant has been removed.
* verify that the corresponding `ios` or `android` config has been removed from the secret in OpenShift