### PR TITLE
updated type field to push

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -585,7 +585,7 @@ func updateConfiguration(appType string, clientId string, variantId string, newC
 	configSecret.Data["uri"] = []byte(pushClient.baseUrl)
 	configSecret.Data["config"] = currentConfigString
 	configSecret.Data["name"] = []byte("ups")
-	configSecret.Data["type"] = []byte("AeroGear Unifiedpush Server")
+	configSecret.Data["type"] = []byte("push")
 
 	// Add the binding annotation to the UPS secret: this is done to link the actual ServiceBinding
 	// Instance back to this secret. In case the variant is deleted in UPS we can use this ID to delete


### PR DESCRIPTION
Changes:

update the type field to push as this is required by the sdk.

This can be verified by using the mobile cli to generate the config and it should look something like this: 

```  
{
	"version": 1,
	"clusterName": "https://10.201.82.45:8443",
	"namespace": "ups-test",
	"clientId": "myapp-ios",
	"services": [
		{
			"id": "ups-secret-myapp-ios-fh00j",
			"name": "ups",
			"type": "push",
			"url": "https://ups-ups-test.10.201.82.45.nip.io",
			"config": {
				"ios": {
					"variantId": "d49e0550-48fe-46e9-8c17-b3ba8b0f698d",
					"variantSecret": "f2060847-f4f9-42fb-83ad-61021917fe70"
				}
			}
		}
	]
}
```